### PR TITLE
gcc-11.2

### DIFF
--- a/khashv.h
+++ b/khashv.h
@@ -134,8 +134,8 @@ static KHASH_FINLINE int khashv_is_little_endian() {
 
 struct khashv_block_s {
     union {
-        uint8_t  bytes[16];
         uint32_t words[4];
+        uint8_t  bytes[16];
         #if defined(__SSE3__)
         __m128i  vec;
         #endif


### PR DESCRIPTION
With this change compiler gcc-11.2 does not throw an error.

Tested with i5-5300u and Slackware-15.0 on https://github.com/rurban/smhasher